### PR TITLE
[add] plane role and associated Kubernetes resources

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -25,3 +25,10 @@
     - role: roles/oslf
   tags:
     - oslf
+
+- name: plane
+  hosts: all
+  roles:
+    - role: roles/plane
+  tags:
+    - plane

--- a/roles/common/tasks/mariadb.yml
+++ b/roles/common/tasks/mariadb.yml
@@ -1,0 +1,36 @@
+- name: Deploy MariaDB Cluster
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: k8s.mariadb.com/v1alpha1
+      kind: MariaDB
+      metadata:
+        name: "mariadb-cluster"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        storage:
+          size: 1Gi
+          storageClassName: "sopec"
+          volumeClaimTemplate:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: "1Gi"
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "750Mi"
+          limits:
+            memory: "1Gi"
+        rootPasswordSecretKeyRef:
+          name: mariadb-cluster-root
+          key: root-password
+          generate: true
+        metrics:
+          enabled: true
+          exporter:
+            resources:
+              requests:
+                cpu: "10m"
+                memory: "64Mi"

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -6,3 +6,4 @@ postgres_users:
   - rallly
   - grist
   - umami
+  - plane

--- a/roles/plane/tasks/admin.yml
+++ b/roles/plane/tasks/admin.yml
@@ -1,0 +1,56 @@
+- name: Create deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ app }}-admin"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-admin"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-admin"
+          spec:
+            containers:
+              - name: "{{ app }}-admin"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-admin:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+
+- name: Create service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-admin"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app.name: "{{ app }}-admin"
+      spec:
+        clusterIP: None
+        ports:
+          - name: admin-3000
+            port: 3000
+            protocol: TCP
+            targetPort: 3000
+        selector:
+          app.name: "{{ app }}-admin"

--- a/roles/plane/tasks/api.yml
+++ b/roles/plane/tasks/api.yml
@@ -1,0 +1,77 @@
+- name: Create service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-api"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app.name: "{{ app }}-api"
+      spec:
+        clusterIP: None
+        ports:
+          - name: api-8000
+            port: 8000
+            protocol: TCP
+            targetPort: 8000
+        selector:
+          app.name: "{{ app }}-api"
+
+- name: Create Deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-api"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-api"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-api"
+          spec:
+            containers:
+              - name: "{{ app }}-api"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-backend:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+                command:
+                  - ./bin/docker-entrypoint-api.sh
+                envFrom:
+                  - configMapRef:
+                      name: "{{ app }}-vars"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-secrets"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-doc-store-secrets"
+                      optional: false
+                readinessProbe:
+                  failureThreshold: 30
+                  httpGet:
+                    path: /
+                    port: 8000
+                    scheme: HTTP
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 1
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"

--- a/roles/plane/tasks/global.yml
+++ b/roles/plane/tasks/global.yml
@@ -1,0 +1,67 @@
+- name: Create serive account
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ app }}-srv-account"
+        namespace: "{{ openshift_namespace }}"
+      imagePullSecrets:
+        - name: "svc0176-pull-secret"
+
+- name: Create application secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ app }}-secrets"
+        namespace: "{{ openshift_namespace }}"
+      type: Opaque
+      stringData:
+        SECRET_KEY: "{{ secrets[openshift_env].secret_key }}"
+        REDIS_URL: "redis://{{ app }}-redis.{{ openshift_namespace }}:6379/"
+        DATABASE_URL: "postgresql://{{ app }}-user:{{ secrets[openshift_env].database.password }}@{{ postgres_cluster.name }}-rw:5432/{{ app }}-db"
+        AMQP_URL: "amqp://{{ app }}:{{ secrets[openshift_env].rabbitmq.password }}@{{ app }}-rabbitmq.{{ openshift_namespace }}:5672/"
+
+- name: Create Doc store secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ app }}-doc-store-secrets"
+        namespace: "{{ openshift_namespace }}"
+      type: Opaque
+      stringData:
+        FILE_SIZE_LIMIT: "5242880"
+        AWS_S3_BUCKET_NAME: "uploads"
+        USE_MINIO: "1"
+        MINIO_ROOT_USER: "{{ app }}"
+        MINIO_ROOT_PASSWORD: "{{ secrets[openshift_env].s3.password }}"
+        AWS_ACCESS_KEY_ID: "{{ app }}"
+        AWS_SECRET_ACCESS_KEY: "{{ secrets[openshift_env].s3.password }}"
+        AWS_S3_ENDPOINT_URL: "http://{{ app }}-minio.{{ openshift_namespace }}:9000"
+
+- name: Create config map for environment variables
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-vars"
+      data:
+        SENTRY_DSN: "{{ secrets[openshift_env].sentry.dsn | default('') }}"
+        SENTRY_ENVIRONMENT: "{{ openshift_env | default('') }}"
+        DEBUG: "0"
+        DOCKERIZED: "1"
+        GUNICORN_WORKERS: "1"
+        MINIO_ENDPOINT_SSL: "0"
+        API_KEY_RATE_LIMIT: "60/minute"
+        WEB_URL: "http://{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        CORS_ALLOWED_ORIGINS: "http://{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }},https://{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"

--- a/roles/plane/tasks/job.yml
+++ b/roles/plane/tasks/job.yml
@@ -1,0 +1,100 @@
+- name: Create minio bucket job
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: "{{ app }}-minio-bucket-1"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        backoffLimit: 6
+        completionMode: NonIndexed
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+          spec:
+            restartPolicy: OnFailure
+            initContainers:
+              - name: init
+                image: quay-its.epfl.ch/svc0176/busybox:latest
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "100Mi"
+                command:
+                  [
+                    "sh",
+                    "-c",
+                    "until nslookup {{ app }}-minio.{{ openshift_namespace }}.svc.cluster.local; do echo waiting for {{ app }}-minio; sleep 2; done",
+                  ]
+            containers:
+              - command:
+                  - /bin/sh
+                args:
+                  - "-c"
+                  - >-
+                    /usr/bin/mc config host add plane-app-minio http://{{ app }}-minio.{{ openshift_namespace }}.svc.cluster.local:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY";
+                    /usr/bin/mc mb plane-app-minio/$AWS_S3_BUCKET_NAME;
+                    /usr/bin/mc anonymous set download plane-app-minio/$AWS_S3_BUCKET_NAME; exit 0;
+                envFrom:
+                  - secretRef:
+                      name: "{{ app }}-doc-store-secrets"
+                      optional: false
+                image: quay-its.epfl.ch/svc0176/minio-mc:latest
+                imagePullPolicy: IfNotPresent
+                name: "{{ app }}-minio-bucket"
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+            terminationGracePeriodSeconds: 120
+
+- name: Create migration job
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-api-migrate-1"
+      spec:
+        backoffLimit: 3
+        template:
+          metadata:
+            labels:
+              app.name: "{{ app }}-api-migrate"
+          spec:
+            containers:
+              - name: "{{ app }}-api-migrate"
+                image: quay-its.epfl.ch/svc0176/plane-backend:stable
+                command:
+                  - ./bin/docker-entrypoint-migrator.sh
+                imagePullPolicy: Always
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                envFrom:
+                  - configMapRef:
+                      name: "{{ app }}-vars"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-secrets"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-doc-store-secrets"
+                      optional: false
+            restartPolicy: OnFailure
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"

--- a/roles/plane/tasks/live.yml
+++ b/roles/plane/tasks/live.yml
@@ -1,0 +1,92 @@
+- name: Create service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-live"
+        labels:
+          app.name: "{{ app }}-live"
+      spec:
+        clusterIP: None
+        ports:
+          - name: live-3000
+            port: 3000
+            protocol: TCP
+            targetPort: 3000
+        selector:
+          app.name: "{{ app }}-live"
+
+- name: Create Deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-live"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-live"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-live"
+          spec:
+            containers:
+              - name: "{{ app }}-live"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-live:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+                envFrom:
+                  - configMapRef:
+                      name: "{{ app }}-live-vars"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-live-secrets"
+                      optional: false
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+
+- name: Create secrets
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-live-secrets"
+      stringData:
+        REDIS_URL: "redis://{{ app }}-redis.{{ openshift_namespace }}.svc.cluster.local:6379/"
+
+- name: Create config map
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-live-vars"
+      data:
+        API_BASE_URL: "http://{{ app }}-api.{{ openshift_namespace }}.svc.cluster.local:8000/"
+        LIVE_SENTRY_DSN: ""
+        LIVE_SENTRY_ENVIRONMENT: ""
+        LIVE_SENTRY_TRACES_SAMPLE_RATE: ""
+        LIVE_BASE_PATH: "/live"

--- a/roles/plane/tasks/main.yml
+++ b/roles/plane/tasks/main.yml
@@ -1,0 +1,116 @@
+- name: Ensure Database
+  include_tasks:
+    file: postgres.yml
+    apply:
+      tags:
+        - plane.postgres
+  tags:
+    - plane.postgres
+
+- name: Create global resources
+  include_tasks:
+    file: global.yml
+    apply:
+      tags:
+        - plane.global
+  tags:
+    - plane.global
+
+- name: Create live resources
+  include_tasks:
+    file: live.yml
+    apply:
+      tags:
+        - plane.live
+  tags:
+    - plane.live
+
+- name: Create api resources
+  include_tasks:
+    file: api.yml
+    apply:
+      tags:
+        - plane.api
+  tags:
+    - plane.api
+
+- name: Create minio resources
+  include_tasks:
+    file: minio.yml
+    apply:
+      tags:
+        - plane.minio
+  tags:
+    - plane.minio
+
+- name: Create rabbitmq resources
+  include_tasks:
+    file: rabbitmq.yml
+    apply:
+      tags:
+        - plane.rabbitmq
+  tags:
+    - plane.rabbitmq
+
+- name: Create redis resources
+  include_tasks:
+    file: redis.yml
+    apply:
+      tags:
+        - plane.redis
+  tags:
+    - plane.redis
+
+- name: Create space resources
+  include_tasks:
+    file: space.yml
+    apply:
+      tags:
+        - plane.space
+  tags:
+    - plane.space
+
+- name: Create web resources
+  include_tasks:
+    file: web.yml
+    apply:
+      tags:
+        - plane.web
+  tags:
+    - plane.web
+
+- name: Create worker resources
+  include_tasks:
+    file: worker.yml
+    apply:
+      tags:
+        - plane.worker
+  tags:
+    - plane.worker
+
+- name: Create admin resources
+  include_tasks:
+    file: admin.yml
+    apply:
+      tags:
+        - plane.admin
+  tags:
+    - plane.admin
+
+- name: Create route resources
+  include_tasks:
+    file: route.yml
+    apply:
+      tags:
+        - plane.route
+  tags:
+    - plane.route
+
+- name: Create job
+  include_tasks:
+    file: job.yml
+    apply:
+      tags:
+        - plane.job
+  tags:
+    - plane.job

--- a/roles/plane/tasks/minio.yml
+++ b/roles/plane/tasks/minio.yml
@@ -1,0 +1,94 @@
+- name: Create minio service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-minio"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}-minio"
+      spec:
+        clusterIP: None
+        ports:
+          - name: minio-api-9000
+            port: 9000
+            protocol: TCP
+            targetPort: 9000
+          - name: minio-console-9090
+            port: 9090
+            protocol: TCP
+            targetPort: 9090
+        selector:
+          app: "{{ app }}-minio"
+
+- name: Create pvc for minio
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-minio"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+        storageClassName: sopec
+        volumeMode: Filesystem
+
+- name: Create minio statefulset
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: "{{ app }}-minio"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        selector:
+          matchLabels:
+            app: "{{ app }}-minio"
+        serviceName: "{{ app }}-minio"
+        template:
+          metadata:
+            labels:
+              app: "{{ app }}-minio"
+          spec:
+            containers:
+              - image: quay-its.epfl.ch/svc0176/minio:latest
+                imagePullPolicy: IfNotPresent
+                name: "{{ app }}-minio"
+                stdin: true
+                tty: true
+                args:
+                  - server
+                  - /data
+                  - --console-address
+                  - :9090
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+                envFrom:
+                  - secretRef:
+                      name: "{{ app }}-doc-store-secrets"
+                      optional: false
+                volumeMounts:
+                  - mountPath: /data
+                    name: data
+                    subPath: ""
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: "{{ app }}-minio"

--- a/roles/plane/tasks/postgres.yml
+++ b/roles/plane/tasks/postgres.yml
@@ -1,0 +1,49 @@
+- name: Create database credentials secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ app }}-db-credentials"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          cnpg.io/reload: "true"
+      type: kubernetes.io/basic-auth
+      stringData:
+        username: "{{ app + '-user' }}"
+        password: "{{ secrets[openshift_env].database.password }}"
+        database: "{{ app + '-db' }}"
+
+- name: Create Database in PostgreSQL Cluster
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: postgresql.cnpg.io/v1
+      kind: Database
+      metadata:
+        name: "{{ app }}"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        cluster:
+          name: "{{ postgres_cluster.name }}"
+        name: "{{ app + '-db' }}"
+        owner: "{{ app + '-user' }}"
+        passwordSecret:
+          name: "{{ app }}-db-credentials"
+
+- name: Create scheduled backup
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      kind: ScheduledBackup
+      apiVersion: postgresql.cnpg.io/v1
+      metadata:
+        name: "{{ app }}-scheduled-backup"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        schedule: "0 2 * * *"
+        backupOwnerReference: "self"
+        cluster:
+          name: "{{ postgres_cluster.name }}"

--- a/roles/plane/tasks/rabbitmq.yml
+++ b/roles/plane/tasks/rabbitmq.yml
@@ -1,0 +1,102 @@
+- name: Create secrets
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      metadata:
+        name: "{{ app }}-rabbitmq-secrets"
+        namespace: "{{ openshift_namespace }}"
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      stringData:
+        RABBITMQ_DEFAULT_USER: "{{ app }}"
+        RABBITMQ_DEFAULT_PASS: "{{ secrets[openshift_env].rabbitmq.password }}"
+
+- name: Create service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-rabbitmq"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app.name: "{{ app }}-rabbitmq"
+      spec:
+        clusterIP: None
+        ports:
+          - name: rabbitmq-5672
+            port: 5672
+            protocol: TCP
+            targetPort: 5672
+          - name: rabbitmq-mgmt-15672
+            port: 15672
+            protocol: TCP
+            targetPort: 15672
+        selector:
+          app.name: "{{ app }}-rabbitmq"
+
+- name: Create pvc for rabbitmq
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-rabbitmq"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "100Mi"
+        storageClassName: sopec
+        volumeMode: Filesystem
+
+- name: Create StatefulSet
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: "{{ app }}-rabbitmq"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-rabbitmq"
+        serviceName: "{{ app }}-rabbitmq"
+        template:
+          metadata:
+            labels:
+              app.name: "{{ app }}-rabbitmq"
+          spec:
+            containers:
+              - image: quay-its.epfl.ch/svc0176/rabbitmq:3.13.6-management-alpine
+                imagePullPolicy: "IfNotPresent"
+                name: "{{ app }}-rabbitmq"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                envFrom:
+                  - secretRef:
+                      name: "{{ app }}-rabbitmq-secrets"
+                      optional: false
+                volumeMounts:
+                  - mountPath: /var/lib/rabbitmq
+                    name: data
+                    subPath: ""
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: "{{ app }}-rabbitmq"

--- a/roles/plane/tasks/redis.yml
+++ b/roles/plane/tasks/redis.yml
@@ -1,0 +1,80 @@
+- name: Create redis service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-redis"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app.name: "{{ app }}-redis"
+      spec:
+        clusterIP: None
+        ports:
+          - name: redis-6379
+            port: 6379
+            protocol: TCP
+            targetPort: 6379
+        selector:
+          app.name: "{{ app }}-redis"
+
+- name: Create pvc for redis
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        namespace: "{{ openshift_namespace }}"
+        name: "{{ app }}-redis"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "100Mi"
+        storageClassName: sopec
+        volumeMode: Filesystem
+
+- name: Create redis StatefulSet
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: "{{ app }}-redis"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-redis"
+        serviceName: "{{ app }}-redis"
+        template:
+          metadata:
+            labels:
+              app.name: "{{ app }}-redis"
+          spec:
+            containers:
+              - image: quay-its.epfl.ch/svc0176/valkey:7.2.5-alpine
+                imagePullPolicy: IfNotPresent
+                name: "{{ app }}-redis"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                volumeMounts:
+                  - mountPath: /data
+                    name: data
+                    subPath: ""
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: "{{ app }}-redis"

--- a/roles/plane/tasks/route.yml
+++ b/roles/plane/tasks/route.yml
@@ -1,0 +1,167 @@
+- name: Create web route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-web"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/"
+        to:
+          kind: Service
+          name: "{{ app }}-web"
+        port:
+          targetPort: 3000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+- name: Create api route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-api"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/api"
+        to:
+          kind: Service
+          name: "{{ app }}-api"
+        port:
+          targetPort: 8000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+- name: Create auth route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-auth"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/auth"
+        to:
+          kind: Service
+          name: "{{ app }}-api"
+        port:
+          targetPort: 8000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+- name: Create live route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-live"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/live/"
+        to:
+          kind: Service
+          name: "{{ app }}-live"
+        port:
+          targetPort: 3000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+- name: Create spaces route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-space"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/spaces"
+        to:
+          kind: Service
+          name: "{{ app }}-space"
+        port:
+          targetPort: 3000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+- name: Create admin route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-admin"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/god-mode"
+        to:
+          kind: Service
+          name: "{{ app }}-admin"
+        port:
+          targetPort: 3000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+- name: Create minio route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: "{{ app }}-minio"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app: "{{ app }}"
+          route: "public-cf"
+      spec:
+        host: "{{ subdomain }}{% if openshift_env == 'test' %}-test{% endif %}.{{ domain }}"
+        path: "/uploads"
+        to:
+          kind: Service
+          name: "{{ app }}-minio"
+        port:
+          targetPort: 9000
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect

--- a/roles/plane/tasks/space.yml
+++ b/roles/plane/tasks/space.yml
@@ -1,0 +1,56 @@
+- name: Create space service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-space"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app.name: "{{ app }}-space"
+      spec:
+        clusterIP: None
+        ports:
+          - name: space-3000
+            port: 3000
+            protocol: TCP
+            targetPort: 3000
+        selector:
+          app.name: "{{ app }}-space"
+
+- name: Create space Deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ app }}-space"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-space"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-space"
+          spec:
+            containers:
+              - name: "{{ app }}-space"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-space:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"

--- a/roles/plane/tasks/web.yml
+++ b/roles/plane/tasks/web.yml
@@ -1,0 +1,56 @@
+- name: Create web service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ app }}-web"
+        namespace: "{{ openshift_namespace }}"
+        labels:
+          app.name: "{{ app }}-web"
+      spec:
+        clusterIP: None
+        ports:
+          - name: web-3000
+            port: 3000
+            protocol: TCP
+            targetPort: 3000
+        selector:
+          app.name: "{{ app }}-web"
+
+- name: Create web deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ app }}-web"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-web"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-web"
+          spec:
+            containers:
+              - name: "{{ app }}-web"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-frontend:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"

--- a/roles/plane/tasks/worker.yml
+++ b/roles/plane/tasks/worker.yml
@@ -1,0 +1,95 @@
+- name: Create beat worker resources
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ app }}-beat-worker"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-beat-worker"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-beat-worker"
+          spec:
+            containers:
+              - name: "{{ app }}-beat-worker"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-backend:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+                command:
+                  - ./bin/docker-entrypoint-beat.sh
+                envFrom:
+                  - configMapRef:
+                      name: "{{ app }}-vars"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-secrets"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-doc-store-secrets"
+                      optional: false
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"
+
+- name: Create worker resources
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ app }}-worker"
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.name: "{{ app }}-worker"
+        template:
+          metadata:
+            namespace: "{{ openshift_namespace }}"
+            labels:
+              app.name: "{{ app }}-worker"
+          spec:
+            containers:
+              - name: "{{ app }}-worker"
+                imagePullPolicy: Always
+                image: "quay-its.epfl.ch/svc0176/plane-backend:stable"
+                stdin: true
+                tty: true
+                resources:
+                  requests:
+                    memory: "50Mi"
+                    cpu: "50m"
+                  limits:
+                    memory: "1000Mi"
+                    cpu: "500m"
+                command:
+                  - ./bin/docker-entrypoint-worker.sh
+                envFrom:
+                  - configMapRef:
+                      name: "{{ app }}-vars"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-secrets"
+                      optional: false
+                  - secretRef:
+                      name: "{{ app }}-doc-store-secrets"
+                      optional: false
+            serviceAccount: "{{ app }}-srv-account"
+            serviceAccountName: "{{ app }}-srv-account"

--- a/roles/plane/vars/main.yml
+++ b/roles/plane/vars/main.yml
@@ -1,0 +1,7 @@
+app: plane
+subdomain: plane
+secrets: "{{ lookup('pipe', 'keybase fs read /keybase/team/epfl_sopec/plane/secrets.yml') | from_yaml }}"
+domain: fsd.epfl.ch
+
+postgres_cluster:
+  name: postgres-cluster


### PR DESCRIPTION
- Introduced a new role for 'plane' with tasks for managing various Kubernetes resources including services, deployments, secrets, and routes.
- Created tasks for managing MariaDB, RabbitMQ, Redis, MinIO, and PostgreSQL resources.
- Added configuration for environment variables and secrets management.
- Implemented job and scheduled backup for PostgreSQL.
- Defined service accounts and persistent volume claims for stateful applications.
- Updated playbook to include the new 'plane' role.